### PR TITLE
Add rewinddir

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1196,12 +1196,12 @@ int do_console(char *path, char *isofile) {
             CatchError(dc_cdfs_redir_read_sectors(isofd, buffer));
         if(!(memcmp(buffer, CMD_GDBPACKET, 4)))
             CatchError(dc_gdbpacket(buffer));
+        if(!(memcmp(buffer, CMD_REWINDDIR, 4)))
+            CatchError(dc_rewinddir(buffer));
 
         // reset the timer
         time.tv_nsec = 500000000;
     }
-    if(!(memcmp(buffer, CMD_REWINDDIR, 4)))
-        CatchError(dc_rewinddir(buffer));
 
     return 0;
 }

--- a/host-src/tool/dcload-types.h
+++ b/host-src/tool/dcload-types.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 
 /* dcload dirent */
-
 typedef struct {
     uint32_t d_ino;    /* inode number */
     int32_t d_off;     /* offset to the next dirent */
@@ -14,7 +13,6 @@ typedef struct {
 } dcload_dirent_t;
 
 /* dcload stat */
-
 typedef struct {
     uint16_t st_dev;
     uint16_t st_ino;

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -344,27 +344,26 @@ int dc_utime(unsigned char *buffer) {
 }
 
 int dc_opendir(unsigned char *buffer) {
-    DIR *somedir;
     command_string_t *command = (command_string_t *)buffer;
-    int i;
+    int hnd;
 
     /* Find an open entry */
-    for(i = 0; i < MAX_OPEN_DIRS; ++i) {
-        if(!opendirs[i])
+    for(hnd = 0; hnd < MAX_OPEN_DIRS; ++hnd) {
+        if(!opendirs[hnd])
             break;
     }
 
-    if(i < MAX_OPEN_DIRS) {
-        if(!(opendirs[i] = opendir(command->string)))
-            i = 0;
+    if(hnd < MAX_OPEN_DIRS) {
+        if(!(opendirs[hnd] = opendir(command->string)))
+            hnd = 0;
         else
-            i += DIRENT_OFFSET;
+            hnd += DIRENT_OFFSET;
     }
     else {
-        i = 0;
+        hnd = 0;
     }
 
-    send_cmd(CMD_RETVAL, (unsigned int)i, (unsigned int)i, NULL, 0);
+    send_cmd(CMD_RETVAL, (unsigned int)hnd, (unsigned int)hnd, NULL, 0);
 
     return 0;
 }
@@ -391,10 +390,10 @@ int dc_readdir(unsigned char *buffer) {
     struct dirent *somedirent;
     dcload_dirent_t dcdirent;
     command_3int_t *command = (command_3int_t *)buffer;
-    uint32_t i = ntohl(command->value0);
+    uint32_t hnd = ntohl(command->value0);
 
-    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET)
-        somedirent = readdir(opendirs[i - DIRENT_OFFSET]);
+    if(hnd >= DIRENT_OFFSET && hnd < MAX_OPEN_DIRS + DIRENT_OFFSET)
+        somedirent = readdir(opendirs[hnd - DIRENT_OFFSET]);
     else
         somedirent = NULL;
 
@@ -431,11 +430,10 @@ int dc_readdir(unsigned char *buffer) {
 int dc_rewinddir(unsigned char *buffer) {
     int retval;
     command_int_t *command = (command_int_t *)buffer;
-    uint32_t i = ntohl(command->value0);
+    uint32_t hnd = ntohl(command->value0);
 
-    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
-        rewinddir(opendirs[i - DIRENT_OFFSET]);
-        opendirs[i - DIRENT_OFFSET] = NULL;
+    if(hnd >= DIRENT_OFFSET && hnd < MAX_OPEN_DIRS + DIRENT_OFFSET) {
+        rewinddir(opendirs[hnd - DIRENT_OFFSET]);
         retval = 0;
     }
     else {

--- a/target-src/dcload/syscalls.c
+++ b/target-src/dcload/syscalls.c
@@ -324,7 +324,7 @@ int utime(const char *filename, struct utimbuf *buf) {
 }
 
 DIR *opendir(const char *name) {
-    command_string_t *command = (command_string_t *)(pkt_buf + ETHER_H_LEN + IP_H_LEN + UDP_H_LEN);
+    command_string_t * command = (command_string_t *)(pkt_buf + ETHER_H_LEN + IP_H_LEN + UDP_H_LEN);
     int namelen = strlen(name);
 
     memcpy(command->id, CMD_OPENDIR, 4);


### PR DESCRIPTION
Add rewinddir support to the host application.  It already exists in the dcload so that means it should work with dcload-ip 2.0.1 cdis